### PR TITLE
Add option to specify executable path via env var

### DIFF
--- a/installkernel.java
+++ b/installkernel.java
@@ -285,6 +285,10 @@ class installkernel implements Callable<Integer> {
      * @return
      */
     private Path findCommand(String cmd) {
+        if ("jbang".equals(cmd) && System.getenv("JBANG_LAUNCH_CMD") != null) {
+            return Path.of(System.getenv("JBANG_LAUNCH_CMD"));
+        }
+
         Path command = null;
         List<String> paths = new ArrayList<>();
 


### PR DESCRIPTION
Jbang is not always discoverable via the PATH, and there's no escape hatch currently. This adds an option to set the JBANG_LAUNCH_CMD env var and use that in preference to the PATH. Jbang sets the env var automatically since version 0.117.0.